### PR TITLE
Fix connection errors when the client tries to connect before the server starts

### DIFF
--- a/client.py
+++ b/client.py
@@ -22,6 +22,7 @@ Sources: DigitalOcean
 ################################################################################
 # Imports
 ################################################################################
+import time
 import socket
 import interfaces.interface_headers as IH
 from interfaces.interface_game_interaction import GameInteractionInterface
@@ -49,8 +50,14 @@ class Client( GameInteractionInterface ):
         """
         
         # Create a client socket and connect to the host socket
-        self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.client_socket.connect((self.host, self.host_port))
+        while True:
+            try:
+                self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.client_socket.connect((self.host, self.host_port))
+                break
+            except:
+                # Keep trying if we hit a connection refused error
+                time.sleep(0.1)
     
     def close_connection( self ) -> None:
         """

--- a/documentation/time_estimates.md
+++ b/documentation/time_estimates.md
@@ -1,3 +1,4 @@
 | Section                      | Estimated Time | Actual Time | Time Log                                                                               |
 | ---------------------------- | -------------- | ----------- | -------------------------------------------------------------------------------------- |
-| Selection TUI                | 3 hours         | 2 hours     | Evan - Friday Sept 20 - 85 min + Saturday Sept 21 - 15 min + Monday Sept 23 - 128 min | 
+| Selection TUI                | 3 hours        | 3.8 hours   | Evan - Friday Sept 20 - 85 min + Saturday Sept 21 - 15 min + Monday Sept 23 - 128 min  | 
+| Bug Fixing                   | 1-2 hours      | 16 minutes  | Evan - Thursday Sept 26                                                                |

--- a/host.py
+++ b/host.py
@@ -64,7 +64,6 @@ class Host( GameInteractionInterface ):
         
         # Store the client socket once a connection is established
         self.client_socket, _ = host_socket.accept()
-        print("found socket")
 
 
     def close_connection( self ) -> None:

--- a/host.py
+++ b/host.py
@@ -21,6 +21,7 @@ Sources: DigitalOcean
 ################################################################################
 # Imports
 ################################################################################
+import time
 import socket
 import interfaces.interface_headers as IH
 from interfaces.interface_game_interaction import GameInteractionInterface
@@ -48,14 +49,22 @@ class Host( GameInteractionInterface ):
         """
         
         # Create and bind a socket to the host ip and port
-        host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        host_socket.bind((self.host, self.host_port))
+        # Try to connect until the socket is no longer in use
+        while True:
+            try:
+                host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                host_socket.bind((self.host, self.host_port))
+                break
+            except:
+                # Keep trying if we hit a socket in use error
+                time.sleep(0.1)
 
         # Listen for connections from a client
         host_socket.listen(1)
         
         # Store the client socket once a connection is established
         self.client_socket, _ = host_socket.accept()
+        print("found socket")
 
 
     def close_connection( self ) -> None:


### PR DESCRIPTION
This PR fixes the connection refused error when the client tries to connect before the server is started. Instead of showing an error, this PR just makes the client wait for the server to start